### PR TITLE
Always parse o.gap as float

### DIFF
--- a/jquery.marquee.js
+++ b/jquery.marquee.js
@@ -128,7 +128,7 @@
             verticalDir = o.direction == 'up' || o.direction == 'down';
 
             //no gap if not duplicated
-            o.gap = o.duplicated ? o.gap : 0;
+            o.gap = o.duplicated ? parseFloat(o.gap) : 0;
 
             //wrap inner content into a div
             $this.wrapInner('<div class="js-marquee"></div>');


### PR DESCRIPTION
This addresses issues when duplicated is true and gap is typeof string.
