### PR TITLE
Reintroduce the concept of speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Options:
  - **direction** Direction towards which the marquee will animate ```'left' / 'right' / 'up' / 'down'```. Default is ```'left'```. Todo: need to change this to ```ltr/rtl``` etc
  - **duplicated** Should the marquee be duplicated to show an effect of continuous flow. Use this only when the text is shorter than the container. Default is ```false```
  - **duration** Duration in milliseconds in which you want your element to travel. Default is ```5000```.
- - **speed** Speed will override duration. Speed allows you to set a relatively constant marquee speed regardless of the width of the containing element.
+ - **speed** Speed will override duration. Speed allows you to set a relatively constant marquee speed regardless of the width of the containing element. Speed is measured in pixels per second.
  - **gap** Gap in pixels between the tickers. Will work only when the ```duplicated``` option is set to ```true```. Default is ```20```. Note: ```20``` means ```20px``` so no need to use ```'20px'``` as the value.
  - **pauseOnHover** On hover pause the marquee. If browser supports CSS3 and ```allowCss3Support``` is set to ```true``` than it will be done using CSS3. Otherwise this will be done using jQuery plugin https://github.com/tobia/Pause. Default is ```false```. Check the demo page for a demo.
  - **pauseOnCycle** On cycle, pause the marquee for ```delayBeforeStart``` milliseconds.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Options:
  - **delayBeforeStart** Time in milliseconds before the marquee starts animating. Default is ```1000```
  - **direction** Direction towards which the marquee will animate ```'left' / 'right' / 'up' / 'down'```. Default is ```'left'```. Todo: need to change this to ```ltr/rtl``` etc
  - **duplicated** Should the marquee be duplicated to show an effect of continuous flow. Use this only when the text is shorter than the container. Default is ```false```
- - **duration** Duration in milliseconds in which you want your element to travel. Default is ```5000```. This option is the old ```speed``` option which still works but duration is the more correct word.
+ - **duration** Duration in milliseconds in which you want your element to travel. Default is ```5000```.
+ - **speed** Speed will override duration. Speed allows you to set a relatively constant marquee speed regardless of the width of the containing element.
  - **gap** Gap in pixels between the tickers. Will work only when the ```duplicated``` option is set to ```true```. Default is ```20```. Note: ```20``` means ```20px``` so no need to use ```'20px'``` as the value.
  - **pauseOnHover** On hover pause the marquee. If browser supports CSS3 and ```allowCss3Support``` is set to ```true``` than it will be done using CSS3. Otherwise this will be done using jQuery plugin https://github.com/tobia/Pause. Default is ```false```. Check the demo page for a demo.
  - **pauseOnCycle** On cycle, pause the marquee for ```delayBeforeStart``` milliseconds.
@@ -89,7 +90,7 @@ or use this if you want to start the plugin with no options but want to use data
  * you can also start the plugin using $('.marquee').marquee(); with defaults
 */
 $('.marquee').marquee({
-	//speed in milliseconds of the marquee
+	//duration in milliseconds of the marquee
 	duration: 15000,
 	//gap in pixels between the tickers
 	gap: 50,

--- a/jquery.marquee.js
+++ b/jquery.marquee.js
@@ -121,8 +121,10 @@
                 }
             });
 
-            // since speed option is changed to duration, to support speed for those who are already using it
-            o.duration = o.speed || o.duration;
+            // Reintroduce speed as an option. It calculates duration as a factor of the container width
+            if (o.speed) {
+                o.duration = o.speed * parseInt($this.width(), 10);
+            }
 
             // Shortcut to see if direction is upward or downward
             verticalDir = o.direction == 'up' || o.direction == 'down';
@@ -169,16 +171,16 @@
 
                 var elHeight = $this.find('.js-marquee:first').height() + o.gap;
 
-                // adjust the animation speed according to the text length
+                // adjust the animation duration according to the text length
                 if (o.startVisible && !o.duplicated) {
                     // Compute the complete animation duration and save it for later reference
-                    // formula is to: (Height of the text node + height of the main container / Height of the main container) * speed;
+                    // formula is to: (Height of the text node + height of the main container / Height of the main container) * duration;
                     o._completeDuration = ((parseInt(elHeight, 10) + parseInt(containerHeight, 10)) / parseInt(containerHeight, 10)) * o.duration;
 
-                    // formula is to: (Height of the text node / height of the main container) * speed
+                    // formula is to: (Height of the text node / height of the main container) * duration
                     o.duration = (parseInt(elHeight, 10) / parseInt(containerHeight, 10)) * o.duration;
                 } else {
-                    // formula is to: (Height of the text node + height of the main container / Height of the main container) * speed;
+                    // formula is to: (Height of the text node + height of the main container / Height of the main container) * duration;
                     o.duration = ((parseInt(elHeight, 10) + parseInt(containerHeight, 10)) / parseInt(containerHeight, 10)) * o.duration;
                 }
 
@@ -189,21 +191,21 @@
                 // container width
                 containerWidth = $this.width();
 
-                // adjust the animation speed according to the text length
+                // adjust the animation duration according to the text length
                 if (o.startVisible && !o.duplicated) {
                     // Compute the complete animation duration and save it for later reference
-                    // formula is to: (Width of the text node + width of the main container / Width of the main container) * speed;
+                    // formula is to: (Width of the text node + width of the main container / Width of the main container) * duration;
                     o._completeDuration = ((parseInt(elWidth, 10) + parseInt(containerWidth, 10)) / parseInt(containerWidth, 10)) * o.duration;
 
-                    // (Width of the text node / width of the main container) * speed
+                    // (Width of the text node / width of the main container) * duration
                     o.duration = (parseInt(elWidth, 10) / parseInt(containerWidth, 10)) * o.duration;
                 } else {
-                    // formula is to: (Width of the text node + width of the main container / Width of the main container) * speed;
+                    // formula is to: (Width of the text node + width of the main container / Width of the main container) * duration;
                     o.duration = ((parseInt(elWidth, 10) + parseInt(containerWidth, 10)) / parseInt(containerWidth, 10)) * o.duration;
                 }
             }
 
-            // if duplicated then reduce the speed
+            // if duplicated then reduce the duration
             if (o.duplicated) {
                 o.duration = o.duration / 2;
             }
@@ -468,7 +470,7 @@
         direction: 'left',
         // true or false - should the marquee be duplicated to show an effect of continues flow
         duplicated: false,
-        // speed in milliseconds of the marquee in milliseconds
+        // duration in milliseconds of the marquee in milliseconds
         duration: 5000,
         // gap in pixels between the tickers
         gap: 20,

--- a/jquery.marquee.js
+++ b/jquery.marquee.js
@@ -122,8 +122,9 @@
             });
 
             // Reintroduce speed as an option. It calculates duration as a factor of the container width
+            // measured in pixels per second.
             if (o.speed) {
-                o.duration = o.speed * parseInt($this.width(), 10);
+                o.duration = parseInt($this.width(), 10) / o.speed * 1000;
             }
 
             // Shortcut to see if direction is upward or downward


### PR DESCRIPTION
Replaced mentions of speed with duration where applicable.

Currently speed is calculated as a factor of the container width. This
isn’t perfect, but works reasonably well. A more perfect solution would
require reworking the duration calculations.

Fixes #58
