### PR TITLE
Fix MS Edge

### DIFF
--- a/jquery.marquee.js
+++ b/jquery.marquee.js
@@ -406,7 +406,7 @@
                         // Bug fixed for jQuery 1.3.x - Instead of using .last(), use following
                         $styles.filter(":last").html(keyframeCss);
                     } else {
-                        $marqueeWrapper.append('<style>' + keyframeCss + '</style>');
+                        $('head').append('<style>' + keyframeCss + '</style>');
                     }
 
                     // Animation iteration event


### PR DESCRIPTION
Edge doesn't like the style tag outside of the head.  Insert the keyframe style code into the head instead of the marquee element.

issue #70 