### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install:
  - **NPM:** `npm install jquery.marquee --save`
  - **CDN:** [jsdelivr.com](http://www.jsdelivr.com/#!jquery.marquee)
 ```html
-<script src="//cdn.jsdelivr.net/jquery.marquee/1.4.0/jquery.marquee.min.js" type="text/javascript"></script>
+<script src="//cdn.jsdelivr.net/gh/aamirafridi/jQuery.Marquee@1.4.1/jquery.marquee.min.js" type="text/javascript"></script>
 ```
 - **Bower**: `bower install jQuery.Marquee`
 - **Download:** [zip](https://github.com/aamirafridi/jQuery.Marquee/archive/master.zip)


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub.  This means all future releases will be available automatically, but will use a new link structure.
I updated the links now so you don't forget to do it when you release a new version.
Serving files from npm is the preferred way, but I noticed that npm is missing the past few versions so I used GitHub links instead.

Feel free to ping me if you have any questions regarding this change.