### PR TITLE
PauseOnHover bug fixed.

### DIFF
--- a/jquery.marquee.js
+++ b/jquery.marquee.js
@@ -441,7 +441,8 @@
             $this.bind('resume', methods.resume);
 
             if (o.pauseOnHover) {
-                $this.bind('mouseenter mouseleave', methods.toggle);
+                $this.bind('mouseenter', methods.pause);
+                $this.bind('mouseleave', methods.resume);
             }
 
             // If css3 animation is supported than call animate method at once


### PR DESCRIPTION
Fixes [#89](https://github.com/aamirafridi/jQuery.Marquee/pull/89).
All credit goes to @dylanfw. Thank you!
Toggle method stays for now.