### PR TITLE
fix testing animation support

### DIFF
--- a/jquery.marquee.js
+++ b/jquery.marquee.js
@@ -221,7 +221,7 @@
                     keyframeString = '';
 
                 // Check css3 support
-                if (elm.style.animation) {
+                if (elm.style.animation !== undefined) {
                     keyframeString = '@keyframes ' + animationName + ' ';
                     css3AnimationIsSupported = true;
                 }


### PR DESCRIPTION
According to:
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Detecting_CSS_animation_support

It looks like you got an error while testing animation support.
Current code doesn't work on IE10 and IE11.